### PR TITLE
Fix issue #4

### DIFF
--- a/cmd/workonCmd.go
+++ b/cmd/workonCmd.go
@@ -35,7 +35,7 @@ var workonCmd = &cobra.Command{
 		// for each context that is defined, it specifies a cluster,
 		// and we want to find out all the namespaces under that cluster.
 		// We should be able to retrieve them if the user specified by the context has those permissions.
-		for name := range config.Contexts {
+		for name, c := range config.Contexts {
 			// modify the config object in place
 			// set the current context to the one we're looking at right now
 			config.CurrentContext = name
@@ -49,11 +49,21 @@ var workonCmd = &cobra.Command{
 			}
 			namespaces, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 			if err != nil {
-				log.Fatal(err)
-			}
-			for _, namespace := range namespaces.Items {
-				// this will be one of the possible selections
-				selections = append(selections, &Selection{Context: name, Namespace: namespace.Name})
+				// If we get any kind of error, we show the current namespace set in the
+				// context and if one is not, we specfy default
+				var namespace string
+				if len(c.Namespace) != 0 {
+					namespace = c.Namespace
+				} else {
+					namespace = "default"
+				}
+
+				selections = append(selections, &Selection{Context: name, Namespace: namespace})
+			} else {
+				for _, namespace := range namespaces.Items {
+					// this will be one of the possible selections
+					selections = append(selections, &Selection{Context: name, Namespace: namespace.Name})
+				}
 			}
 		}
 		// by this point, the selections slice is completely instantiated

--- a/cmd/workonCmd.go
+++ b/cmd/workonCmd.go
@@ -49,6 +49,7 @@ var workonCmd = &cobra.Command{
 			}
 			namespaces, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 			if err != nil {
+				log.Printf("Error querying namespaces with context: %s. Error: %v\n", name, err)
 				// If we get any kind of error, we show the current namespace set in the
 				// context and if one is not, we specfy default
 				var namespace string


### PR DESCRIPTION
Fixes issue #4 

When retrieving the list of namespaces in one of the clusters, if we get an error, the current behavior is to fail flat. However, that's not ideal.

Hence, in case we get any error when retrieving the list of namespaces, we default to the context's namespace only in the list of selections offered to the user.